### PR TITLE
Compat for StaticArrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 julia = "1"
+StaticArrays = "0.12,1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
For Julia >1.6 we need  a compat for StaticArrays. I have added 0.12 for backward compatibility with Julia <1.5